### PR TITLE
potential fix for azimuthal winds in SH

### DIFF
--- a/src/nodes/NodeFileEditor.cpp
+++ b/src/nodes/NodeFileEditor.cpp
@@ -203,6 +203,11 @@ void CalculateRadialProfile(
 
 		// Calculate azimuthal velocity
 		double dUa = dUx * dAx + dUy * dAy + dUz * dAz;
+		
+                // Azimuthal convention positive if cyclonic, flip in SH
+                if (dLat0 < 0.0) {
+			dUa = -dUa;
+		}
 
 		//printf("%1.5e %1.5e :: %1.5e %1.5e\n", dUlon, dUlat, dUr, dUa);
 


### PR DESCRIPTION
Generally, azimuthal winds (i.e., associated with a tropical cyclone) are defined +cyclonic -- in the SH, this requires the dUa calculation to be flipped. Currently, NodeFileFilter does not return correct values for variable such as r8 unless specified as + in the NH and - in the SH.