### PR TITLE
Mark operator== const to avoid ambiguity in C++20.

### DIFF
--- a/src/base/Variable.cpp
+++ b/src/base/Variable.cpp
@@ -764,7 +764,7 @@ DataOp * VariableRegistry::GetDataOp(
 
 bool Variable::operator==(
 	const Variable & var
-) {
+) const {
 	if (m_fOp != var.m_fOp) {
 		return false;
 	}

--- a/src/base/Variable.h
+++ b/src/base/Variable.h
@@ -617,7 +617,7 @@ public:
 	///	<summary>
 	///		Equality operator.
 	///	</summary>
-	bool operator==(const Variable & var);
+	bool operator==(const Variable & var) const;
 
 	///	<summary>
 	///		Get the name of this Variable.


### PR DESCRIPTION
C++20 will automatically generate an operator== with reversed operand order, which is ambiguous with the written operator== when one argument is marked const and the other isn't.

(By the way, thanks for this excellent tool -- we have found it to be really useful for our work!)