### PR TITLE
Temporary fix for missing values/NaN incompatibility for SyCLoPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TempestExtremes can be built and installed on various systems using CMake. Our n
 - **Installation Locations:** Final executables are installed to `./bin` and libraries/archives to `./lib`.
 
 ## Quick-Make Scripts for generic Linux/Unix-based systems
-A ready-to-use `./quick_make_unix.sh` script is available for end users to run on common UNIX-based platforms such as MacOS and Linux, as well as on command HPC systems like NERSC Perlmutter and NCAR Derecho.
+A ready-to-use `./quick_make_unix.sh` script is available for end users to run on common UNIX-based platforms such as MacOS and Linux, as well as on command HPC systems like NERSC Perlmutter and NCAR Derecho. To start the installation:
 ```
 cd TEMPEST_EXTREMES_SOURCE_DIR
 sh quick_make_unix.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install from conda use the command line:
 ```conda install -c conda-forge tempest-extremes```
 
 
-# Installation via CMake
+# Installation via CMake (Recommended)
 
 TempestExtremes can be built and installed on various systems using CMake. Our new script, `./quick_make_unix.sh`, automatically detects your platform(UNIX-based systems only) and loads any required modules before building.
 
@@ -37,25 +37,27 @@ TempestExtremes can be built and installed on various systems using CMake. Our n
 - **Out-of-Source Build:** Build files are generated in `./build/bin` (keeping the source directory clean).
 - **Installation Locations:** Final executables are installed to `./bin` and libraries/archives to `./lib`.
 
-## Quick-Make Scripts for generic Linux/Unix based systems
+## Quick-Make Scripts for generic Linux/Unix-based systems
 A ready-to-use `./quick_make_unix.sh` script is available for end users to run on common UNIX-based platforms such as MacOS and Linux, as well as on command HPC systems like NERSC Perlmutter and NCAR Derecho.
+```
+cd TEMPEST_EXTREMES_SOURCE_DIR
+sh quick_make_unix.sh
+```
 ### System/Platforms Detection in `quick_make_unix.sh`
 - **MacOS/Linux (Generic):** The script runs the default commands.
 - **NERSC Perlmutter:** The script automatically loads `cray-hdf5` and `cray-netcdf` modules before building.
 - **NCAR Derecho:** The script loads required modules such as `ncarenv`, `ncarcompilers`, `intel`, `cray-mpich`, and `netcdf`.
-- **Windows:** This bash script is prepared for UNIX-like environments. If you're on Windows, please refer to the Windows instructions below. If you have a bash environment on Windows but the script fails to run automatically, simply run the commands manually starting from `./remove_depend.sh`.
+- **Windows:** This bash script is prepared for UNIX-like environments. If you're on Windows, please refer to the Windows instructions below.
 - **Unknown/Other:** If your system isn’t recognized or errors occur (often due to non-standard dependency paths), don’t panic—simply run the commands manually starting from `./remove_depend.sh` and fix the related errors shown in the terminal.
-
 
 Notes:
 - **For End Users:**  
-  If you only need the final deliverables, run the quick-make script. It will install executables to `./bin` and (by default) remove the build directory for a clean structure.
+  If you only need the final deliverables, you only need to run the quick-make script. It will install executables to `./bin` and (by default) remove the build directory for a clean structure.
 
 - **For Developers:**  
   The `./build` directory is used for development and debugging. It contains all intermediate files, which helps speed up incremental builds. Developers should keep the build directory intact (by commenting out the cleanup step) for faster rebuilds.  
 
-
-To use `./quick_make_unix.sh` , update the configuration options in the script:
+In `./quick_make_unix.sh`, update the configuration options in the script if needed:
 ```bash
 # Configuration Options
 BUILD_TYPE="Release"          # "Debug" or "Release"
@@ -66,8 +68,6 @@ INSTALL_PREFIX=""             # Specify the installation directory. If left blan
                               # the project root (TEMPEST_EXTREMES_SOURCE_DIR) and final executables 
                               # will be installed in TEMPEST_EXTREMES_SOURCE_DIR/bin.
 ```
-The run `./quick_make_unix.sh`.
-
 ## Unix/Linux-Based Systems (Manual Install)
 
 If you are using Nersc Permultter, you will need to run this first:
@@ -107,10 +107,10 @@ cmake -G "Visual Studio 17" -DCMAKE_INSTALL_PREFIX=PATH_TO_INSTALL -DNetCDF_ROOT
 
 
 1. **Using the Quick Make Script:**  
-   If you are a developer using `./quick_make_general.sh`, remember to comment out or remove the cleanup step at the end (e.g. `make clean`). It's not efficient to rebuild the entire project every time you make changes—this script is mainly for a full rebuild or for end users who want a clean install. For faster incremental builds during development, build manually so that intermediate files are preserved.
+   If you are a developer using `./quick_make_general.sh`, remember to comment out or remove the cleanup step at the end (e.g., `make clean`). It's not efficient to rebuild the entire project every time you make changes—this script is mainly for a full rebuild or for end users who want a clean install. For faster incremental builds during development, build manually so that intermediate files are preserved.
 
 2. **Adding New Executables:**  
-   To add a new executable to the project, refer to following examples:
+   To add a new executable to the project, refer to the following examples:
 
    **Example: Adding a New Executable**  
    For example, to add `NewBlobsFeature`:

--- a/src/base/DataOp.cpp
+++ b/src/base/DataOp.cpp
@@ -421,7 +421,6 @@ bool DataOp_VECMAG::Apply(
 	const SimpleGrid & grid,
 	const std::vector<std::string> & strArg,
 	const std::vector<DataArray1D<float> const *> & vecArgData,
-	// const DataArray1D<real> & dataout
 	DataArray1D<float> & dataout
 ) {
 	if (strArg.size() != 2) {
@@ -444,8 +443,6 @@ bool DataOp_VECMAG::Apply(
 					+ dataRight[i] * dataRight[i]);
 		} else {
 				dataout[i]=std::numeric_limits<double>::quiet_NaN();
-				// dataout[i]=dataLeft.GetFillValue();
-				// printf("%f\n",dataout[i]);
 				}
 	}
 
@@ -1911,11 +1908,9 @@ void BuildCurlOperator(
 			
 			opCurlE(i,i) += dScale * dCoeff0 * dAzLonCoeffI;
 			opCurlN(i,i) += dScale * dCoeff0 * dAzLatCoeffI;
-			// printf("%.6e\n",opCurlE(i,k));
 
 			opCurlE(i,k) += dScale * dCoeff1 * dAzLonCoeffK;
 			opCurlN(i,k) += dScale * dCoeff1 * dAzLatCoeffK;
-			// printf("%.6e\n",opCurlE(i,k));
 		}
 
 		if (setPoints.size() < 4) {
@@ -1970,7 +1965,6 @@ bool DataOp_CURL::Apply(
 
 		m_fInitialized = true;
 	}
-	
 	m_opCurlE.Apply(*(vecArgData[0]), dataout, true);
 	m_opCurlN.Apply(*(vecArgData[1]), dataout, false); 
 

--- a/src/base/DataOp.cpp
+++ b/src/base/DataOp.cpp
@@ -1905,7 +1905,6 @@ void BuildCurlOperator(
 			double dAzLatCoeffK = - sin(dLatRadK) * (cos(dLonRadK) * dAxK + sin(dLonRadK) * dAyK) + cos(dLatRadK) * dAzK;
 
 			// Add contributions to sparse matrix operator
-			
 			opCurlE(i,i) += dScale * dCoeff0 * dAzLonCoeffI;
 			opCurlN(i,i) += dScale * dCoeff0 * dAzLatCoeffI;
 

--- a/src/base/SparseMatrix.h
+++ b/src/base/SparseMatrix.h
@@ -18,7 +18,6 @@
 #define _SPARSEMATRIX_H_
 
 #include "DataArray1D.h"
-
 #include <map>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -190,8 +189,13 @@ public:
 
 		SparseMapConstIterator iter = m_mapEntries.begin();
 		for (; iter != m_mapEntries.end(); iter++) {
-			dataVectorOut[iter->first.first] +=
+			if (dataVectorIn[iter->first.second]>1e19){
+				// dataVectorOut[iter->first.first] += std::numeric_limits<double>::quiet_NaN();
+				continue;
+			} else {
+				dataVectorOut[iter->first.first] +=
 				iter->second * dataVectorIn[iter->first.second];
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a temporary fix for missing values or NaN incompatibility when using SyCLoPS (the System for Classification of Low-Pressure Systems) with some model/reanalysis datasets. It only made changes to the operators used by SyCLoPS. A full repair to support missing values for all Tempestextremes operations is expected in the near future. Some changes are made to the README to improve clarity.